### PR TITLE
Correctly handle WebSocket-over-HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Install this starter kit to use Fanout. It routes incoming requests through the Fanout GRIP proxy and on to an origin. It also provides some endpoints for testing subscriptions without an origin.
 
-There is no need to modify this kit. It is production-ready for typical Fanout usage that coordinates with an origin. However, if you would like to implement Fanout logic at the edge, this kit is also a good starting point for that and you can modify it to fit your needs. See the test endpoints for inspiration.
+There is no need to modify this starter kit. It is production-ready for typical Fanout usage that coordinates with an origin. However, if you would like to implement Fanout logic at the edge, this starter kit is also a good starting point for that, and you can modify it to fit your needs. See the test endpoints for inspiration.
 
 **For more details about this and other starter kits for Compute, see the [Fastly Documentation Hub](https://www.fastly.com/documentation/solutions/starters/)**.
 
@@ -23,7 +23,7 @@ For requests made to domains ending in `.edgecompute.app`, the app will handle r
 * `/test/sse`: SSE (streaming of `text/event-stream`)
 * `/test/long-poll`: Long-polling
 
-Connecting to any of these endpoints will subscribe the connection to channel "test". The WebSocket endpoint echos back any messages it receives from the client.
+Connecting to any of these endpoints will subscribe the connection to channel "test". The WebSocket endpoint echoes back any messages it receives from the client.
 
 Data can be sent to the connections via the GRIP publish endpoint at `https://api.fastly.com/service/{service-id}/publish/`. For example, here's a curl command to send a WebSocket message:
 

--- a/fanoutUtil.go
+++ b/fanoutUtil.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"github.com/fastly/compute-sdk-go/fsthttp"
+	"net/http"
+)
+
+// GripResponse returns a GRIP response to initialize a stream
+// When Compute receives a non-WebSocket request (i.e. normal HTTP) and wants
+// to make it long lived (longpoll or SSE), we call handoff_fanout on it, and
+// Fanout will then forward that request to the nominated backend.  In this app,
+// that backend is this same Compute service, where we then need to respond
+// with some Grip headers to tell Fanout to hold the connection for streaming.
+// This function constructs such a response.
+//
+// Parameters:
+//
+//	ctype - Value of Content-Type header to specify
+//	ghold - Value of Grip-Hold to specify on the response
+//	channel - Name of Grip channel to subscribe the response
+func GripResponse(w fsthttp.ResponseWriter, ctype string, ghold string, channel string) {
+	w.Header().Add("Content-Type", ctype)
+	w.Header().Add("Grip-Hold", ghold)
+	w.Header().Add("Grip-Channel", channel)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(""))
+}
+
+// WsText returns a WebSocket-over-HTTP formatted TEXT message
+//
+// Parameters:
+//
+//	msg - Text message to send
+func WsText(msg string) []byte {
+	return []byte(fmt.Sprintf("TEXT %2x\r\n%s\r\n", len(msg), msg))
+}
+
+// WsSub returns a channel-subscription command in a WebSocket-over-HTTP format
+//
+// Parameters:
+//
+//	channel - Name of Grip channel to subscribe to
+func WsSub(channel string) []byte {
+	return WsText(fmt.Sprintf("c:{\"type\":\"subscribe\",\"channel\":\"%s\"}", channel))
+}


### PR DESCRIPTION
This is equivalent to fastly/compute-starter-kit-rust-fanout#20.

> The main difference in this fix is that we are first starting by cloning the incoming request's body directly into the response's body. This is the correct behavior, because the request body may contain more than one encoded WebSocket message in a batch, and to be an echo server all of these messages need to be echoed directly back to the response.
>
> Additionally, OPEN is guaranteed to be the first one in a batch, so checking the first few bytes for it works. If it is found, then the handler adds the subscribe message and WebSocket extension header to the response.