### PR TITLE
Update starter kit for CLI 15.2 and local testing of Fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ The app expects a configured backend named `"origin"`. It forwards all non-test 
 
 Additionally, for the test endpoints to work, the app expects a configured backend named `"self"` that points back to app itself. For example, if the service has a domain `foo.edgecompute.app`, then you'll need to create a backend on the service named `"self"` with the destination host set to `foo.edgecompute.app` and port 443. Also set "Override Host" to the same host value.
 
-You'll also need to [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) on your Fastly service to run this application. To enable Fanout on your service, type:
+### Enabling Fanout
+
+The first time this starter kit is deployed to your service, Fanout is enabled automatically.
+
+To [enable Fanout](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#enable-fanout) support after the fact to an existing Fastly service, type:
 
 ```shell
 fastly products --enable=fanout
 ```
 
-## Local testing
+## Testing locally
 
 To test Fanout features in the local testing environment, first obtain [Pushpin](https://pushpin.org), the open-source GRIP proxy server that Fastly Fanout is based upon, and make sure it is available on the system path.
 
@@ -58,7 +62,7 @@ Run the starter kit:
 fastly compute serve
 ```
 
-The Fastly CLI starts Pushpin and then starts the starter kit app at http://localhost:7676/.  
+The Fastly CLI starts Pushpin and then starts the starter kit app at http://localhost:7676/.
 
 ## Test Endpoints
 
@@ -99,9 +103,10 @@ For test requests, the app is actually invoked twice.
 
 2. Since `self` refers to the same app, a second request is made to the same app, this time coming through Fanout. The app checks for this, and then handles the request accordingly (in `handle_test()`).
 
-## Note
+## Compatibility
 
-This app is not currently supported in Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server), as the development server does not support Fanout features. To experiment with Fanout, you will need to publish this project to your Fastly Compute service. using the `fastly compute publish` command.
+- [Fastly CLI](https://www.fastly.com/documentation/reference/tools/cli/) 15.2.0 or newer
+- [Fastly Local Development Server (Viceroy)](https://www.fastly.com/documentation/guides/compute/developer-guides/testing/#running-a-local-testing-server) 0.18.0 or newer
 
 ## Security issues
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -19,6 +19,14 @@ override_host = "example.com"
 url = "http://localhost:7676/"
 override_host = "localhost:7676"
 
+[setup.backends]
+[setup.backends.origin]
+[setup.backends.self]
+
+[setup.products]
+[setup.products.fanout]
+enable = true
+
 [scripts]
 build = "go build -o bin/main.wasm ."
 env_vars = ["GOARCH=wasm", "GOOS=wasip1"]


### PR DESCRIPTION
This PR updates the starter kit to improve user experience:

- Adds setup for the Fanout product as well as backends as they will be needed in the actual service
- Makes README text consistent with this starter kit in other languages as well as the WebSocket passthrough starter kit regarding enabling the product
- Removes note in README saying this doesn't work in local testing, as it is now supported since Viceroy 0.18
